### PR TITLE
add readinessProbe initialDelaySeconds

### DIFF
--- a/incubator/logstash/README.md
+++ b/incubator/logstash/README.md
@@ -31,28 +31,29 @@ chart and deletes the release.
 
 The following tables lists the configurable parameters of the drone charts and their default values.
 
-|              Parameter              |                    Description                     |                     Default                      |
-| ----------------------------------- | -------------------------------------------------- | ------------------------------------------------ |
-| `replicaCount`                      | Number of replicas                                 | `1`                                              |
-| `nodeSelector`                      | Node selectors                                     | `{}`                                             |
-| `livenessProbe.initialDelaySeconds` | initialDelaySeconds of Pod livenessProbe           | `60`                                             |
-| `livenessProbe.periodSeconds`       | periodSeconds of Pod livenessProbe                 | `20`                                             |
-| `nodeSelector`                      | Node selectors                                     | `{}`                                             |
-| `image.repository`                  | Container image name                               | `docker.elastic.co/logstash/logstash-oss`        |
-| `image.tag`                         | Container image tag                                | `6.2.1`                                          |
-| `image.pullPolicy`                  | Container image pull policy                        | `IfNotPresent`                                   |
-| `service.type`                      | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP`                                      |
-| `service.internalPort`              | Logstash internal port                             | `1514`                                           |
-| `service.ports`                     | Service open ports                                 | `[TCP/1514, UDP/1514, TCP/5044]`                 |
-| `ingress.enabled`                   | Enables Ingress                                    | `false`                                          |
-| `ingress.annotations`               | Ingress annotations                                | `{}`                                             |
-| `ingress.hosts`                     | Ingress accepted hostnames                         | `[]`                                             |
-| `ingress.tls`                       | Ingress TLS configuration                          | `nil`                                            |
-| `resources`                         | Pod resource requests & limits                     | `{}`                                             |
-| `elasticsearch.host`                | ElasticSearch hostname                             | `elasticsearch-client.default.svc.cluster.local` |
-| `elasticsearch.port`                | ElasticSearch port                                 | `9200`                                           |
-| `configData`                        | Extra logstash config                              | `{}`                                             |
-| `patterns`                          | Logstash patterns configuration                    | `nil`                                            |
-| `inputs`                            | Logstash inputs configuration                      | `(basic)`                                        |
-| `filters`                           | Logstash filters configuration                     | `nil`                                            |
-| `outputs`                           | Logstash outputs configuration                     | `(basic)`                                        |
+|              Parameter               |                    Description                     |                     Default                      |
+| -----------------------------------  | -------------------------------------------------- | ------------------------------------------------ |
+| `replicaCount`                       | Number of replicas                                 | `1`                                              |
+| `nodeSelector`                       | Node selectors                                     | `{}`                                             |
+| `livenessProbe.initialDelaySeconds`  | initialDelaySeconds of Pod livenessProbe           | `60`                                             |
+| `livenessProbe.periodSeconds`        | periodSeconds of Pod livenessProbe                 | `20`                                             |
+| `readinessProbe.initialDelaySeconds` | initialDelaySeconds of Pod readinessProbe          | `60`                                             |
+| `nodeSelector`                       | Node selectors                                     | `{}`                                             |
+| `image.repository`                   | Container image name                               | `docker.elastic.co/logstash/logstash-oss`        |
+| `image.tag`                          | Container image tag                                | `6.2.1`                                          |
+| `image.pullPolicy`                   | Container image pull policy                        | `IfNotPresent`                                   |
+| `service.type`                       | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP`                                      |
+| `service.internalPort`               | Logstash internal port                             | `1514`                                           |
+| `service.ports`                      | Service open ports                                 | `[TCP/1514, UDP/1514, TCP/5044]`                 |
+| `ingress.enabled`                    | Enables Ingress                                    | `false`                                          |
+| `ingress.annotations`                | Ingress annotations                                | `{}`                                             |
+| `ingress.hosts`                      | Ingress accepted hostnames                         | `[]`                                             |
+| `ingress.tls`                        | Ingress TLS configuration                          | `nil`                                            |
+| `resources`                          | Pod resource requests & limits                     | `{}`                                             |
+| `elasticsearch.host`                 | ElasticSearch hostname                             | `elasticsearch-client.default.svc.cluster.local` |
+| `elasticsearch.port`                 | ElasticSearch port                                 | `9200`                                           |
+| `configData`                         | Extra logstash config                              | `{}`                                             |
+| `patterns`                           | Logstash patterns configuration                    | `nil`                                            |
+| `inputs`                             | Logstash inputs configuration                      | `(basic)`                                        |
+| `filters`                            | Logstash filters configuration                     | `nil`                                            |
+| `outputs`                            | Logstash outputs configuration                     | `(basic)`                                        |

--- a/incubator/logstash/templates/deployment.yaml
+++ b/incubator/logstash/templates/deployment.yaml
@@ -27,12 +27,13 @@ spec:
     {{- end }}
           livenessProbe:
             tcpSocket:
-              initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-              periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
               port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:
             tcpSocket:
               port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           env:
             - name: ELASTICSEARCH_HOST
               value: {{ .Values.elasticsearch.host | quote }}

--- a/incubator/logstash/values.yaml
+++ b/incubator/logstash/values.yaml
@@ -27,6 +27,8 @@ configData: {}
 livenessProbe:
   initialDelaySeconds: 60
   periodSeconds: 20
+readinessProbe:
+  initialDelaySeconds: 120
 
 ingress:
   enabled: false


### PR DESCRIPTION
Doing some testing on your branch after running into similar issues, and needed to extend `readinessProbe` `initialDelaySeconds`, as well as fix the yaml indentation.

See https://github.com/kubernetes/charts/pull/3651#pullrequestreview-96260224